### PR TITLE
Adds specified free-surface grad forcing

### DIFF
--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -945,11 +945,19 @@
 	<nml_record name="pressure_gradient" mode="forward">
 		<nml_option name="config_pressure_gradient_type" type="character" default_value="pressure_and_zmid" units="unitless"
 					description="Form of pressure gradient terms in momentum equation. For most applications, the gradient of pressure and layer mid-depth are appropriate.  For isopycnal coordinates, one may use the gradient of the Montgomery potential.  The sea surface height gradient (ssh_gradient) option is for barotropic, depth-averaged pressure."
-					possible_values="'ssh_gradient', 'pressure_and_zmid' or 'Jacobian_from_density' or 'Jacobian_from_TS' or 'MontgomeryPotential'"
+					possible_values="'ssh_gradient', 'pressure_and_zmid' or 'Jacobian_from_density' or 'Jacobian_from_TS' or 'MontgomeryPotential' or 'constant_forced'"
 		/>
 		<nml_option name="config_common_level_weight" type="real" default_value="0.5" units="unitless"
 					description="The weight between standard Jacobian and weighted Jacobian, $\gamma$."
 					possible_values="any real between 0 and 1"
+		/>
+		<nml_option name="config_zonal_ssh_grad" type="real" default_value="0.0" units="unitless"
+					description="The zonal (x) ssh gradient to be applied."
+					possible_values="any real"
+		/>
+		<nml_option name="config_meridional_ssh_grad" type="real" default_value="0.0" units="unitless"
+					description="The meridional (y) ssh gradient to be applied."
+					possible_values="any real"
 		/>
 	</nml_record>
 	<nml_record name="eos">

--- a/src/core_ocean/shared/mpas_ocn_vel_pressure_grad.F
+++ b/src/core_ocean/shared/mpas_ocn_vel_pressure_grad.F
@@ -55,8 +55,6 @@ module ocn_vel_pressure_grad
    !
    !--------------------------------------------------------------------
 
-!   character (len=StrKIND), pointer :: config_pressure_gradient_type
-!   real (kind=RKIND), pointer :: config_common_level_weight
    logical :: pgradOn
    real (kind=RKIND) :: density0Inv, gdensity0Inv, inv12
 
@@ -80,6 +78,8 @@ contains
 
    subroutine ocn_vel_pressure_grad_tend(meshPool, ssh, pressure, montgomeryPotential, zMid, density, potentialDensity, &
       indexT, indexS, tracers, tend, err, inSituThermalExpansionCoeff,inSituSalineContractionCoeff)!{{{
+
+      implicit none
 
       !-----------------------------------------------------------------
       !
@@ -140,7 +140,8 @@ contains
       real (kind=RKIND), dimension(:), pointer :: dcEdge
       real (kind=RKIND), dimension(:), allocatable :: JacobianDxDs,JacobianTz,JacobianSz,T1,T2,S1,S2
       real (kind=RKIND), dimension(:,:), allocatable :: FXTop, work1, work2
-      real (kind=RKIND) :: invdcEdge, pGrad, sumAJTop, AJTop, FC, FCPrev, alpha, beta
+      real (kind=RKIND) :: invdcEdge, pGrad, sumAJTop, AJTop, FC, FCPrev, alpha, beta, pressureGrad
+      real (kind=RKIND), dimension(:), pointer :: angleEdge
 
       err = 0
 
@@ -155,6 +156,7 @@ contains
       call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
       call mpas_pool_get_array(meshPool, 'dcEdge', dcEdge)
       call mpas_pool_get_array(meshPool, 'edgeMask', edgeMask)
+      call mpas_pool_get_array(meshPool, 'angleEdge', angleEdge)
 
       nEdges = nEdgesArray( 1 )
 
@@ -332,6 +334,22 @@ contains
          !$omp end do
 
          deallocate(JacobianDxDs,JacobianTz,JacobianSz, T1, T2, S1, S2)
+
+     elseif (config_pressure_gradient_type.eq.'constant_forced') then
+
+         !$omp do schedule(runtime) private(cell1, cell2, invdcEdge, k)
+         do iEdge=1,nEdges
+            cell1 = cellsOnEdge(1,iEdge)
+            cell2 = cellsOnEdge(2,iEdge)
+
+            ! compute the pressure gradient to be applied at the edge
+            pressureGrad = config_zonal_ssh_grad * cos(angleEdge(iEdge)) + config_meridional_ssh_grad * sin(angleEdge(iEdge))
+
+            do k=1,maxLevelEdgeTop(iEdge)
+               tend(k,iEdge) = tend(k,iEdge) - edgeMask(k,iEdge) * density0Inv * pressureGrad
+            end do
+         end do
+         !$omp end do
 
       else
 
@@ -683,4 +701,4 @@ contains
 
 end module ocn_vel_pressure_grad
 
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+

--- a/testing_and_setup/compass/ocean/periodic_planar/2.5km/default_gotm/config_analysis.xml
+++ b/testing_and_setup/compass/ocean/periodic_planar/2.5km/default_gotm/config_analysis.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<config case="analysis">
+	<add_link source="../forward/output.nc" dest="output.nc"/>
+	<add_link source="../plot_profile.py" dest="plot_profile.py"/>
+
+	<run_script name="run.py">
+		<step executable="./plot_profile.py">
+		</step>
+	</run_script>
+</config>

--- a/testing_and_setup/compass/ocean/periodic_planar/2.5km/default_gotm/config_driver.xml
+++ b/testing_and_setup/compass/ocean/periodic_planar/2.5km/default_gotm/config_driver.xml
@@ -1,0 +1,11 @@
+<driver_script name="run_test.py">
+	<case name="init">
+		<step executable="./run.py" quiet="true" pre_message=" * Running init" post_message="     Complete"/>
+	</case>
+	<case name="forward">
+		<step executable="./run.py" quiet="true" pre_message=" * Running forward" post_message="     Complete"/>
+	</case>
+	<case name="analysis">
+		<step executable="./run.py" quiet="true" pre_message=" * Running analysis" post_message="     Complete"/>
+	</case>
+</driver_script>

--- a/testing_and_setup/compass/ocean/periodic_planar/2.5km/default_gotm/config_forward.xml
+++ b/testing_and_setup/compass/ocean/periodic_planar/2.5km/default_gotm/config_forward.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0"?>
+<config case="forward">
+	<add_link source="../init/ocean.nc" dest="init.nc"/>
+	<add_link source="../init/mesh.nc" dest="mesh.nc"/>
+	<add_link source="../init/graph.info" dest="graph.info"/>
+
+	<add_executable source="model" dest="ocean_model"/>
+
+	<namelist name="namelist.ocean" mode="forward">
+		<option name="config_ocean_run_mode">'forward'</option>
+		<option name="config_dt">'000:00:25'</option>
+		<option name="config_btr_dt">'000:00:25'</option>
+		<option name="config_time_integrator">'split_explicit'</option>
+		<option name="config_run_duration">'0000_12:00:00'</option>
+		<option name="config_zonal_ssh_grad">-1.0e-5</option>
+		<option name="config_pressure_gradient_type">'constant_forced'</option>
+		<option name="config_use_cvmix">.true.</option>
+		<option name="config_use_cvmix_background">.true.</option>
+		<option name="config_cvmix_background_viscosity">1e-3</option>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="forward">
+		<stream name="mesh">
+			<attribute name="filename_template">mesh.nc</attribute>
+		</stream>
+		<stream name="input">
+			<attribute name="filename_template">init.nc</attribute>
+		</stream>
+		<stream name="output">
+			<attribute name="type">output</attribute>
+			<attribute name="filename_template">output.nc</attribute>
+			<attribute name="output_interval">0000-00-00_00:10:00</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<add_contents>
+				<member name="velocityZonal" type="var"/>
+				<member name="velocityMeridional" type="var"/>
+				<member name="mesh" type="stream"/>
+				<member name="xtime" type="var"/>
+				<member name="normalVelocity" type="var"/>
+				<member name="layerThickness" type="var"/>
+			</add_contents>
+		</stream>
+	</streams>
+
+	<run_script name="run.py">
+		<model_run procs="1" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+</config>

--- a/testing_and_setup/compass/ocean/periodic_planar/2.5km/default_gotm/config_init.xml
+++ b/testing_and_setup/compass/ocean/periodic_planar/2.5km/default_gotm/config_init.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0"?>
+<config case="init">
+
+	<add_executable source="model" dest="ocean_model"/>
+
+	<namelist name="namelist.ocean" mode="init">
+		<option name="config_init_configuration">'periodic_planar'</option>
+		<option name="config_vert_levels">-1</option>
+		<option name="config_periodic_planar_vert_levels">25</option>
+		<option name="config_periodic_planar_bottom_depth">15.0</option>
+		<option name="config_periodic_planar_velocity_strength">0.0</option>
+		<option name="config_ocean_run_mode">'init'</option>
+		<option name="config_write_cull_cell_mask">.false.</option>
+		<option name="config_vertical_grid">'uniform'</option>
+	</namelist>
+
+	<streams name="streams.ocean" keep="immutable" mode="init">
+		<stream name="input_init">
+			<attribute name="filename_template">mesh.nc</attribute>
+		</stream>
+		<stream name="output_init">
+			<attribute name="type">output</attribute>
+			<attribute name="output_interval">0000_00:00:01</attribute>
+			<attribute name="clobber_mode">truncate</attribute>
+			<attribute name="filename_template">ocean.nc</attribute>
+			<add_contents>
+				<member name="input_init" type="stream"/>
+				<member name="layerThickness" type="var"/>
+				<member name="restingThickness" type="var"/>
+				<member name="refBottomDepth" type="var"/>
+				<member name="bottomDepth" type="var"/>
+				<member name="maxLevelCell" type="var"/>
+				<member name="vertCoordMovementWeights" type="var"/>
+				<member name="edgeMask" type="var"/>
+			</add_contents>
+    </stream>
+	</streams>
+
+	<run_script name="run.py">
+		<step executable="planar_hex">
+			<argument flag="--nx">4</argument>
+			<argument flag="--ny">4</argument>
+			<argument flag="--dc">2500.0</argument>
+			<argument flag="--npy"></argument>
+			<argument flag="-o">grid.nc</argument>
+		</step>
+		<step executable="MpasCellCuller.x">
+			<argument flag="">grid.nc</argument>
+			<argument flag="">culled_mesh.nc</argument>
+		</step>
+		<step executable="MpasMeshConverter.x">
+			<argument flag="">culled_mesh.nc</argument>
+			<argument flag="">mesh.nc</argument>
+		</step>
+		<model_run procs="1" threads="1" namelist="namelist.ocean" streams="streams.ocean"/>
+	</run_script>
+
+</config>

--- a/testing_and_setup/compass/ocean/periodic_planar/2.5km/default_gotm/plot_profile.py
+++ b/testing_and_setup/compass/ocean/periodic_planar/2.5km/default_gotm/plot_profile.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+
+import xarray as xr
+import matplotlib.pyplot as plt
+
+# render statically by default
+plt.switch_backend('agg')
+
+if __name__ == "__main__":
+
+  ds = xr.open_dataset('output.nc')
+  u = ds.velocityZonal.isel(Time=-1).mean('nCells').values*100.
+  z = ds.refBottomDepth.values
+  plt.plot(u,z, 'k-')
+  plt.xlabel('Velocity (cm/s)')
+  plt.ylabel('Depth (m)')
+  plt.gca().invert_yaxis()
+  plt.savefig('velocity_profile.png')
+
+


### PR DESCRIPTION
Adds free surface gradient forcing for
 * config_zonal_ssh_grad (x-component for planar)
 * config_meridional_ssh_grad (y-component for planar)

Case is applied in periodic flow in
`ocean/periodic_planar/2.5km/default_gotm` case, which can be
used to validate vertical momentum balances with constant forcing
due to double periodicity.

The title above should be a 1 line short summary of the pull request (i.e. what the project the PR represents is intended to do).

Enter a description of this PR. This should include why this PR was created, and what it does.

Testing and relations to other Pull Requests should be added as subsequent comments.

See the below examples for more information.
https://github.com/MPAS-Dev/MPAS/pull/930
https://github.com/MPAS-Dev/MPAS/pull/931

